### PR TITLE
Compilation fix for Emscripten, which defines __clang__ but does not have __int128

### DIFF
--- a/include/arch.h.in
+++ b/include/arch.h.in
@@ -110,12 +110,9 @@
 /**< Note - no 128-bit type available    */
 #else
 #define chunk int64_t		/**< C type corresponding to word length */
-#ifdef __GNUC__
-#define dchunk __int128		/**< Always define double length chunk type if available - GCC supports 128 bit type  ??? */
-#endif
 
-#ifdef __clang__
-#define dchunk __int128
+#if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
+#define dchunk __int128		/**< Always define double length chunk type if available (supported by GCC & Clang on 64-bit architectures) */
 #endif
 
 #endif


### PR DESCRIPTION
Restores the compile fix for Emscripten, which does not support __int128.

It came with https://github.com/milagro-crypto/milagro-crypto-c/pull/194, but was remove
in commit https://github.com/milagro-crypto/milagro-crypto-c/commit/c588b6f0d6cb82bcfe9aedebf54927e01797820e#diff-f241e3acda6847a4096609195d7813daL109

I assume it was not removed intentionally. This PR should make it work on Emscripten again, and should not break gcc and clang.