### PR TITLE
Update Dockerfile for the builder imaege

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN dpkg --add-architecture i386 \
     parallel \
     python-pip \
     python-setuptools\
-    wine \
+    wine-stable \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && pip install \


### PR DESCRIPTION
The builder image Dockerfile was broken for Ubuntu 18.04 due to
different package name for wine.