### PR TITLE
Use hashed Id input values for WCC secret generation

### DIFF
--- a/examples/testwcc_ZZZ.c.in
+++ b/examples/testwcc_ZZZ.c.in
@@ -48,29 +48,35 @@ int main()
     char bkeyG2[4*WCC_PFS_ZZZ];
     octet BKeyG2= {0,sizeof(bkeyG2), bkeyG2};
 
+    // Identities
     char alice_id[256],bob_id[256];
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
 
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};    
+    
     char x[WCC_PGS_ZZZ];
-    octet X= {0,sizeof(x),x};
+    octet X = {0,sizeof(x),x};
     char y[WCC_PGS_ZZZ];
-    octet Y= {0,sizeof(y),y};
+    octet Y = {0,sizeof(y),y};
     char w[WCC_PGS_ZZZ];
-    octet W= {0,sizeof(w),w};
+    octet W = {0,sizeof(w),w};
     char pia[WCC_PGS_ZZZ];
-    octet PIA= {0,sizeof(pia),pia};
+    octet PIA = {0,sizeof(pia),pia};
     char pib[WCC_PGS_ZZZ];
-    octet PIB= {0,sizeof(pib),pib};
+    octet PIB = {0,sizeof(pib),pib};
 
     char pgg1[2*WCC_PFS_ZZZ+1];
-    octet PgG1= {0,sizeof(pgg1), pgg1};
+    octet PgG1 = {0,sizeof(pgg1), pgg1};
 
     char pag1[2*WCC_PFS_ZZZ+1];
-    octet PaG1= {0,sizeof(pag1), pag1};
+    octet PaG1 = {0,sizeof(pag1), pag1};
 
     char pbg2[4*WCC_PFS_ZZZ];
-    octet PbG2= {0,sizeof(pbg2), pbg2};
+    octet PbG2 = {0,sizeof(pbg2), pbg2};
 
     char seed[32] = {0};
     octet SEED = {0,sizeof(seed),seed};
@@ -123,8 +129,11 @@ int main()
     // Alice's ID
     OCT_jstring(&IdA,"alice@miracl.com");
 
+    // Hash Alice's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+    
     // TA: Generate Alices's sender key
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -138,8 +147,11 @@ int main()
     // Bob's ID
     OCT_jstring(&IdB,"bob@miracl.com");
 
+    // Hash Bob's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+    
     // TA: Generate Bob's receiver key
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G2_MULTIPLE() Error %d\n", rtn);
@@ -165,7 +177,7 @@ int main()
     printf("\n");
 #endif
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
         printf("Alice WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -193,7 +205,7 @@ int main()
     OCT_output(&W);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -216,7 +228,7 @@ int main()
     OCT_output(&Y);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -340,6 +352,8 @@ int main()
     OCT_clear(&BKeyG2);
     OCT_clear(&IdA);
     OCT_clear(&IdB);
+    OCT_clear(&HIdA);
+    OCT_clear(&HIdB);    
     OCT_clear(&X);
     OCT_clear(&Y);
     OCT_clear(&W);

--- a/examples/testwcc_dta_ZZZ.c.in
+++ b/examples/testwcc_dta_ZZZ.c.in
@@ -55,9 +55,15 @@ int main()
     char bkeyG2[4*WCC_PFS_ZZZ];
     octet BKeyG2= {0,sizeof(bkeyG2), bkeyG2};
 
+    // Identities    
     char alice_id[256],bob_id[256];
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
+
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};    
 
     char x[WCC_PGS_ZZZ];
     octet X= {0,sizeof(x),x};
@@ -134,14 +140,17 @@ int main()
     // Alice's ID
     OCT_jstring(&IdA,"alice@miracl.com");
 
+    // Hash Alice's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+    
     // TA: Generate Alice's sender key
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS1,&IdA,&A1KeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS1,&HIdA,&A1KeyG1);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
         return 1;
     }
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS2,&IdA,&A2KeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS2,&HIdA,&A2KeyG1);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
@@ -164,14 +173,17 @@ int main()
     // Bob's ID
     OCT_jstring(&IdB,"bob@miracl.com");
 
+    // Hash Bob's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+
     // TA: Generate Bob's receiver key
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS1,&IdB,&B1KeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS1,&HIdB,&B1KeyG2);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G2_MULTIPLE Error %d\n", rtn);
         return 1;
     }
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS2,&IdB,&B2KeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS2,&HIdB,&B2KeyG2);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G2_MULTIPLE Error %d\n", rtn);
@@ -205,7 +217,7 @@ int main()
     printf("\n");
 #endif
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
         printf("Alice WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
@@ -233,7 +245,7 @@ int main()
     OCT_output(&W);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
@@ -256,7 +268,7 @@ int main()
     OCT_output(&Y);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
@@ -384,6 +396,8 @@ int main()
     OCT_clear(&BKeyG2);
     OCT_clear(&IdA);
     OCT_clear(&IdB);
+    OCT_clear(&HIdA);
+    OCT_clear(&HIdB);
     OCT_clear(&X);
     OCT_clear(&Y);
     OCT_clear(&W);

--- a/include/wcc.h.in
+++ b/include/wcc.h.in
@@ -84,13 +84,12 @@ void WCC_ZZZ_Hq(int sha,octet *A,octet *B,octet *C,octet *D,octet *h);
  * <li> VG2 = s*H2(ID)
  * </ol>
  *
- * @param  sha       Hash type
  * @param  S         integer modulus curve order
- * @param  ID        ID Value or sha256(ID)
+ * @param  HID       Hash of ID padded with zeros to the field size
  * @param  VG2       EC Point VG2 = s*H2(ID)
  * @return rtn       Returns 0 if successful or else an error code
  */
-int WCC_ZZZ_GET_G2_MULTIPLE(int sha,octet *S,octet *ID,octet *VG2);
+int WCC_ZZZ_GET_G2_MULTIPLE(octet *S,octet *HID,octet *VG2);
 
 /**
  * @brief Calculate value in G1 multiplied by an integer
@@ -101,13 +100,12 @@ int WCC_ZZZ_GET_G2_MULTIPLE(int sha,octet *S,octet *ID,octet *VG2);
  * <li> VG1 = s*H1(ID)
  * </ol>
  *
- * @param  sha         Hash type
  * @param  S           integer modulus curve order
- * @param  ID          ID value or sha256(ID)
+ * @param  HID         Hash of ID padded with zeros to the field size
  * @param  VG1         EC point VG1 = s*H1(ID)
  * @return rtn         Returns 0 if successful or else an error code
  */
-int WCC_ZZZ_GET_G1_MULTIPLE(int sha,octet *S,octet *ID,octet *VG1);
+int WCC_ZZZ_GET_G1_MULTIPLE(octet *S,octet *HID,octet *VG1);
 
 /**
  * @brief Calculate the sender AES key

--- a/src/wcc.c.in
+++ b/src/wcc.c.in
@@ -73,15 +73,12 @@ void WCC_ZZZ_Hq(int sha, octet *A,octet *B,octet *C,octet *D,octet *h)
 }
 
 /*  Calculate a value in G1. VG1 = s*H1(ID) where ID is the identity */
-int WCC_ZZZ_GET_G1_MULTIPLE(int sha, octet *S,octet *ID,octet *VG1)
+int WCC_ZZZ_GET_G1_MULTIPLE(octet *S,octet *HID,octet *VG1)
 {
     BIG_XXX s;
     ECP_ZZZ P;
-    char h[WCC_PFS_ZZZ];
-    octet H= {0,sizeof(h),h};
 
-    mhashit(sha,0,ID,&H);
-    ECP_ZZZ_mapit(&P,&H);
+    ECP_ZZZ_mapit(&P,HID);
 
     BIG_XXX_fromBytes(s,S->val);
     PAIR_ZZZ_G1mul(&P,s);
@@ -92,15 +89,12 @@ int WCC_ZZZ_GET_G1_MULTIPLE(int sha, octet *S,octet *ID,octet *VG1)
 
 
 /* Calculate a value in G2. VG2 = s*H2(ID) where ID is the identity */
-int WCC_ZZZ_GET_G2_MULTIPLE(int sha, octet *S,octet *ID,octet *VG2)
+int WCC_ZZZ_GET_G2_MULTIPLE(octet *S,octet *HID,octet *VG2)
 {
     BIG_XXX s;
     ECP2_ZZZ P;
-    char h[WCC_PFS_ZZZ];
-    octet H= {0,sizeof(h),h};
 
-    mhashit(sha,0,ID,&H);
-    ECP2_ZZZ_mapit(&P,&H);
+    ECP2_ZZZ_mapit(&P,HID);
 
     BIG_XXX_fromBytes(s,S->val);
     PAIR_ZZZ_G2mul(&P,s);

--- a/test/test_wcc_ZZZ.c.in
+++ b/test/test_wcc_ZZZ.c.in
@@ -52,9 +52,15 @@ int main()
     char bkeyG2[4*WCC_PFS_ZZZ];
     octet BKeyG2= {0,sizeof(bkeyG2), bkeyG2};
 
+    // Identities    
     char alice_id[256],bob_id[256];
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
+
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};     
 
     char x[WCC_PGS_ZZZ];
     octet X= {0,sizeof(x),x};
@@ -123,8 +129,11 @@ int main()
     // Alice's ID
     OCT_jstring(&IdA,"alice@miracl.com");
 
+    // Hash Alice's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+
     // TA: Generate Alice's sender key
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -134,8 +143,11 @@ int main()
     // Bob's ID
     OCT_jstring(&IdB,"bob@miracl.com");
 
+    // Hash Bob's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+
     // TA: Generate Bob's receiver key
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2);
     if (rtn != 0)
     {
         printf("TA WCC_ZZZ_GET_G2_MULTIPLE() Error %d\n", rtn);
@@ -152,7 +164,7 @@ int main()
     printf("X: 0x");
     OCT_output(&X);
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
         printf("Alice WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -165,7 +177,7 @@ int main()
         printf("Bob WCC_ZZZ_RANDOM_GENERATE() Error %d\n", rtn);
         return 1;
     }
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);
@@ -179,7 +191,7 @@ int main()
         return 1;
     }
 
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
     if (rtn != 0)
     {
         printf("Bob WCC_ZZZ_GET_G1_MULTIPLE() Error %d\n", rtn);

--- a/test/test_wcc_bad_receiver_key_ZZZ.c.in
+++ b/test/test_wcc_bad_receiver_key_ZZZ.c.in
@@ -32,22 +32,7 @@
 #include "randapi.h"
 #include "wcc_ZZZ.h"
 
-// #define DEBUG
-
-void rand_str(octet* dest, csprng *RNG)
-{
-    BIG_XXX r;
-    char charset[] = "0123456789@.*"
-                     "abcdefghijklmnopqrstuvwxyz"
-                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-    for(; dest->len < dest->max; dest->len++)
-    {
-        BIG_XXX_random(r,RNG);
-        size_t index = r[0] % (sizeof charset -1);
-        dest->val[dest->len] = charset[index];
-    }
-}
+#define DEBUG
 
 int main()
 {
@@ -69,11 +54,17 @@ int main()
     char ekeyG2[4*WCC_PFS_ZZZ];
     octet EKeyG2= {0,sizeof(ekeyG2), ekeyG2};
 
-    // Parties identities
+    // Identities
     char alice_id[256],bob_id[256],eve_id[256];
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
     octet IdE= {0,sizeof(eve_id),eve_id};
+
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ], hide[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};
+    octet HIdE = {0,sizeof(hide),hide};        
 
     // Ephemeral and intermediate values
     char x[WCC_PGS_ZZZ];
@@ -101,7 +92,6 @@ int main()
     char k2[WCC_PAS];
     octet K1= {0,sizeof(k1),k1};
     octet K2= {0,sizeof(k2),k2};
-
 
     // Zero octet
     char zero[WCC_PAS];
@@ -141,18 +131,21 @@ int main()
     /* Generate key material for Alice, Bob and Eve */
 
     // Alice's ID
-    rand_str(&IdA,&RNG);
+    OCT_jstring(&IdA,"alice@miracl.com");
 #ifdef DEBUG
     printf("ALICE ID:");
     OCT_output_string(&IdA);
     printf("\n");
 #endif
 
+    // Hash Alice's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+
     // TA: Generate Alice's sender key
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1);
     if (rtn != 0)
     {
-        printf("TA WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1) Error %d\n", rtn);
+        printf("TA WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -161,19 +154,21 @@ int main()
 #endif
 
     // Bob's ID
-    rand_str(&IdB,&RNG);
+    OCT_jstring(&IdB,"bob@miracl.com");
 #ifdef DEBUG
     printf("BOB ID:");
     OCT_output_string(&IdB);
     printf("\n");
 #endif
 
+    // Hash Bob's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+
     // TA: Generate Bob's receiver key
-    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&IdB);
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2);
     if (rtn != 0)
     {
-        printf("TA WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2) Error %d\n", rtn);
+        printf("TA WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -182,19 +177,21 @@ int main()
 #endif
 
     // Eve's ID
-    rand_str(&IdE,&RNG);
+    OCT_jstring(&IdE,"eve@miracl.com");
 #ifdef DEBUG
     printf("EVE ID:");
     OCT_output_string(&IdE);
     printf("\n");
 #endif
 
+    // Hash Eve's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdE,&HIdE);
+
     // TA: Generate Eve's receiver key
-    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdE,&IdE);
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdE,&EKeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdE,&EKeyG2);
     if (rtn != 0)
     {
-        printf("TA WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdE,&EKeyG2) Error %d\n", rtn);
+        printf("TA WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdE,&EKeyG2) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -221,10 +218,10 @@ int main()
     printf("\n");
 #endif
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
-        printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1) Error %d\n", rtn);
+        printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1) Error %d\n", rtn);
         return 1;
     }
 
@@ -253,10 +250,10 @@ int main()
     OCT_output(&W);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
-        printf("Bob WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
+        printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -276,16 +273,25 @@ int main()
     OCT_output(&Y);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
     if (rtn != 0)
     {
-        printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2) Error %d\n", rtn);
+        printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2) Error %d\n", rtn);
         return 1;
     }
 
 #ifdef DEBUG
+    printf("Bob PaG1: ");
+    OCT_output(&PaG1);
+    printf("\n");
     printf("Bob PbG2: ");
     OCT_output(&PbG2);
+    printf("\n");
+    printf("Bob PgG1: ");
+    OCT_output(&PgG1);
+    printf("\n");
+    printf("Bob IdB: ");
+    OCT_output(&IdB);
     printf("\n");
 #endif
 
@@ -401,10 +407,10 @@ int main()
     printf("\n");
 #endif
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
-        printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1) Error %d\n", rtn);
+        printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1) Error %d\n", rtn);
         return 1;
     }
 
@@ -433,10 +439,10 @@ int main()
     OCT_output(&W);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
-        printf("Eve WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1) Error %d\n", rtn);
+        printf("Eve WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -456,10 +462,10 @@ int main()
     OCT_output(&Y);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdE,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdE,&PbG2);
     if (rtn != 0)
     {
-        printf("Eve WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdE,&PbG2) Error %d\n", rtn);
+        printf("Eve WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdE,&PbG2) Error %d\n", rtn);
         return 1;
     }
 

--- a/test/test_wcc_bad_sender_key_ZZZ.c.in
+++ b/test/test_wcc_bad_sender_key_ZZZ.c.in
@@ -32,22 +32,7 @@
 #include "randapi.h"
 #include "wcc_ZZZ.h"
 
-// #define DEBUG
-
-void rand_str(octet* dest, csprng *RNG)
-{
-    BIG_XXX r;
-    char charset[] = "0123456789@.*"
-                     "abcdefghijklmnopqrstuvwxyz"
-                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-    for(; dest->len < dest->max; dest->len++)
-    {
-        BIG_XXX_random(r,RNG);
-        size_t index = r[0] % (sizeof charset -1);
-        dest->val[dest->len] = charset[index];
-    }
-}
+#define DEBUG
 
 int main()
 {
@@ -69,11 +54,17 @@ int main()
     char bkeyG2[4*WCC_PFS_ZZZ];
     octet BKeyG2= {0,sizeof(bkeyG2), bkeyG2};
 
-    // Parties identities
+    // Identities
     char alice_id[256],bob_id[256],eve_id[256];
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
     octet IdE= {0,sizeof(eve_id),eve_id};
+
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ], hide[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};
+    octet HIdE = {0,sizeof(hide),hide};        
 
     // Ephemeral and intermediate values
     char x[WCC_PGS_ZZZ];
@@ -101,7 +92,6 @@ int main()
     char k2[WCC_PAS];
     octet K1= {0,sizeof(k1),k1};
     octet K2= {0,sizeof(k2),k2};
-
 
     // Zero octet
     char zero[WCC_PAS];
@@ -141,18 +131,21 @@ int main()
     /* Generate key material for Alice, Bob and Eve */
 
     // Alice's ID
-    rand_str(&IdA,&RNG);
+    OCT_jstring(&IdA,"alice@miracl.com");
 #ifdef DEBUG
     printf("ALICE ID:");
     OCT_output_string(&IdA);
     printf("\n");
 #endif
 
+    // Hash Alice's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+
     // TA: Generate Alice's sender key
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1);
     if (rtn != 0)
     {
-        printf("TA WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1) Error %d\n", rtn);
+        printf("TA WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -161,19 +154,21 @@ int main()
 #endif
 
     // Bob's ID
-    rand_str(&IdB,&RNG);
+    OCT_jstring(&IdB,"bob@miracl.com");
 #ifdef DEBUG
     printf("BOB ID:");
     OCT_output_string(&IdB);
     printf("\n");
 #endif
 
+    // Hash Bob's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+
     // TA: Generate Bob's receiver key
-    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&IdB);
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2);
     if (rtn != 0)
     {
-        printf("TA WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2) Error %d\n", rtn);
+        printf("TA WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -182,18 +177,21 @@ int main()
 #endif
 
     // Eve's ID
-    rand_str(&IdE,&RNG);
+    OCT_jstring(&IdE,"eve@miracl.com");
 #ifdef DEBUG
     printf("EVE ID:");
     OCT_output_string(&IdE);
     printf("\n");
 #endif
 
+    // Hash Eve's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdE,&HIdE);
+
     // TA: Generate Eve's sender key
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdE,&EKeyG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdE,&EKeyG1);
     if (rtn != 0)
     {
-        printf("TA WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdE,&EKeyG1) Error %d\n", rtn);
+        printf("TA WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdE,&EKeyG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -202,6 +200,7 @@ int main()
 #endif
 
     /* TEST RUN: Check that the protocol is working when using the right receiver key */
+
 
 #ifdef DEBUG
     printf("Control Run. Alice:\n");
@@ -219,10 +218,10 @@ int main()
     printf("\n");
 #endif
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
-        printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1) Error %d\n", rtn);
+        printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1) Error %d\n", rtn);
         return 1;
     }
 
@@ -251,10 +250,10 @@ int main()
     OCT_output(&W);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
-        printf("Bob WCC_ZZZ_GET_G1_MULTIPLE Error %d\n", rtn);
+        printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -274,16 +273,25 @@ int main()
     OCT_output(&Y);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
     if (rtn != 0)
     {
-        printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2) Error %d\n", rtn);
+        printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2) Error %d\n", rtn);
         return 1;
     }
 
 #ifdef DEBUG
+    printf("Bob PaG1: ");
+    OCT_output(&PaG1);
+    printf("\n");
     printf("Bob PbG2: ");
     OCT_output(&PbG2);
+    printf("\n");
+    printf("Bob PgG1: ");
+    OCT_output(&PgG1);
+    printf("\n");
+    printf("Bob IdB: ");
+    OCT_output(&IdB);
     printf("\n");
 #endif
 
@@ -399,10 +407,10 @@ int main()
     printf("\n");
 #endif
 
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
     if (rtn != 0)
     {
-        printf("Eve WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1) Error %d\n", rtn);
+        printf("Eve WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1) Error %d\n", rtn);
         return 1;
     }
 
@@ -431,10 +439,10 @@ int main()
     OCT_output(&W);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
     if (rtn != 0)
     {
-        printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1) Error %d\n", rtn);
+        printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1) Error %d\n", rtn);
         return 1;
     }
 #ifdef DEBUG
@@ -454,10 +462,10 @@ int main()
     OCT_output(&Y);
     printf("\n");
 #endif
-    rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
     if (rtn != 0)
     {
-        printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2) Error %d\n", rtn);
+        printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2) Error %d\n", rtn);
         return 1;
     }
 

--- a/test/test_wcc_invalid_points_ZZZ.c.in
+++ b/test/test_wcc_invalid_points_ZZZ.c.in
@@ -55,6 +55,11 @@ int main()
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
 
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};
+    
     // Ephemeral parameters
     char x[WCC_PGS_ZZZ];
     octet X= {0,sizeof(x),x};
@@ -107,23 +112,33 @@ int main()
     /* TA: Generate master secret  */
     WCC_ZZZ_RANDOM_GENERATE(&RNG,&MS);
 
-    // TA: Generate Alice's sender key
+    // Alice's ID    
     OCT_jstring(&IdA,"alice@miracl.com");
-    WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdA,&AKeyG1);
 
-    // TA: Generate Bob's receiver key
+    // Hash Alice's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+
+    // TA: Generate Alice's sender key    
+    WCC_ZZZ_GET_G1_MULTIPLE(&MS,&HIdA,&AKeyG1);
+
+    // Bob's ID
     OCT_jstring(&IdB,"bob@miracl.com");
-    WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS,&IdB,&BKeyG2);
+
+    // Hash Bob's Id
+    HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+    
+    // TA: Generate Bob's receiver key    
+    WCC_ZZZ_GET_G2_MULTIPLE(&MS,&HIdB,&BKeyG2);
 
     // Generate ephemeral parameters
     WCC_ZZZ_RANDOM_GENERATE(&RNG,&X);
-    WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+    WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
 
     WCC_ZZZ_RANDOM_GENERATE(&RNG,&W);
-    WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+    WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
 
     WCC_ZZZ_RANDOM_GENERATE(&RNG,&Y);
-    WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+    WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
 
     WCC_ZZZ_Hq(HASH_TYPE_WCC_ZZZ,&PaG1,&PbG2,&PgG1,&IdB,&PIA);
     WCC_ZZZ_Hq(HASH_TYPE_WCC_ZZZ,&PbG2,&PaG1,&PgG1,&IdA,&PIB);

--- a/test/test_wcc_random_ZZZ.c.in
+++ b/test/test_wcc_random_ZZZ.c.in
@@ -73,9 +73,15 @@ int main()
     char bkeyG2[4*WCC_PFS_ZZZ];
     octet BKeyG2= {0,sizeof(bkeyG2), bkeyG2};
 
+    // Identities    
     char alice_id[256],bob_id[256];
     octet IdA= {0,sizeof(alice_id),alice_id};
     octet IdB= {0,sizeof(bob_id),bob_id};
+
+    // Hash of the identities
+    char hida[WCC_PFS_ZZZ], hidb[WCC_PFS_ZZZ];
+    octet HIdA = {0,sizeof(hida),hida};
+    octet HIdB = {0,sizeof(hidb),hidb};    
 
     char x[WCC_PGS_ZZZ];
     octet X= {0,sizeof(x),x};
@@ -180,17 +186,20 @@ int main()
         OCT_output_string(&IdA);
         printf("\n");
 
+        // Hash Alice's Id
+        HASH_ID(HASH_TYPE_WCC_ZZZ,&IdA,&HIdA);
+	
         // TA: Generate Alice's sender key
-        rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS1,&IdA,&A1KeyG1);
+        rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS1,&HIdA,&A1KeyG1);
         if (rtn != 0)
         {
-            printf("TA WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS1,&IdA,&A1KeyG1) Error %d\n", rtn);
+            printf("TA WCC_ZZZ_GET_G1_MULTIPLE(&MS1,&HIdA,&A1KeyG1) Error %d\n", rtn);
             return 1;
         }
-        rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS2,&IdA,&A2KeyG1);
+        rtn = WCC_ZZZ_GET_G1_MULTIPLE(&MS2,&HIdA,&A2KeyG1);
         if (rtn != 0)
         {
-            printf("TA WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS2,&IdA,&A2KeyG1) Error %d\n", rtn);
+            printf("TA WCC_ZZZ_GET_G1_MULTIPLE(&MS2,&HIdA,&A2KeyG1) Error %d\n", rtn);
             return 1;
         }
         printf("TA A1KeyG1: ");
@@ -213,17 +222,20 @@ int main()
         OCT_output_string(&IdB);
         printf("\n");
 
+        // Hash Bob's Id
+        HASH_ID(HASH_TYPE_WCC_ZZZ,&IdB,&HIdB);
+	
         // TA: Generate Bob's receiver key
-        rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS1,&IdB,&B1KeyG2);
+        rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS1,&HIdB,&B1KeyG2);
         if (rtn != 0)
         {
-            printf("TA WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS1,&IdB,&B1KeyG2) Error %d\n", rtn);
+            printf("TA WCC_ZZZ_GET_G2_MULTIPLE(&MS1,&HIdB,&B1KeyG2) Error %d\n", rtn);
             return 1;
         }
-        rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS2,&IdB,&B2KeyG2);
+        rtn = WCC_ZZZ_GET_G2_MULTIPLE(&MS2,&HIdB,&B2KeyG2);
         if (rtn != 0)
         {
-            printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&MS2,&IdB,&B2KeyG2) Error %d\n", rtn);
+            printf("Bob WCC_ZZZ_GET_G2_MULTIPLE(&MS2,&HIdB,&B2KeyG2) Error %d\n", rtn);
             return 1;
         }
         printf("TA B1KeyG2: ");
@@ -254,10 +266,10 @@ int main()
         printf("\n");
 #endif
 
-        rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&X,&IdA,&PaG1);
+        rtn = WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1);
         if (rtn != 0)
         {
-            printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,date,&X,&IdA,&PaG1) Error %d\n", rtn);
+            printf("Alice WCC_ZZZ_GET_G1_MULTIPLE(&X,&HIdA,&PaG1) Error %d\n", rtn);
             return 1;
         }
 
@@ -282,10 +294,10 @@ int main()
         OCT_output(&W);
         printf("\n");
 #endif
-        rtn = WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1);
+        rtn = WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1);
         if (rtn != 0)
         {
-            printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&W,&IdA,&PgG1) Error %d\n", rtn);
+            printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(&W,&HIdA,&PgG1) Error %d\n", rtn);
             return 1;
         }
 #ifdef DEBUG
@@ -305,10 +317,10 @@ int main()
         OCT_output(&Y);
         printf("\n");
 #endif
-        rtn = WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2);
+        rtn = WCC_ZZZ_GET_G2_MULTIPLE(&Y,&HIdB,&PbG2);
         if (rtn != 0)
         {
-            printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,&Y,&IdB,&PbG2) Error %d\n", rtn);
+            printf("Bob WCC_ZZZ_GET_G1_MULTIPLE(&Y,&HIdB,&PbG2) Error %d\n", rtn);
             return 1;
         }
 #ifdef DEBUG

--- a/wrappers/python/wcc_ZZZ.py.in
+++ b/wrappers/python/wcc_ZZZ.py.in
@@ -72,8 +72,9 @@ extern void KILL_CSPRNG(csprng *R);
 
 extern int WCC_ZZZ_RANDOM_GENERATE(csprng *RNG,octet* S);
 extern void WCC_ZZZ_Hq(int sha, octet *A,octet *B,octet *C,octet *D,octet *h);
-extern int WCC_ZZZ_GET_G2_MULTIPLE(int sha, octet *S,octet *ID,octet *VG2);
-extern int WCC_ZZZ_GET_G1_MULTIPLE(int sha, octet *S,octet *ID,octet *VG1);
+extern void HASH_ID(int sha, octet *,octet *);
+extern int WCC_ZZZ_GET_G2_MULTIPLE(octet *S,octet *HID,octet *VG2);
+extern int WCC_ZZZ_GET_G1_MULTIPLE(octet *S,octet *HID,octet *VG1);
 extern int WCC_ZZZ_SENDER_KEY(int sha, octet *xOct, octet *piaOct, octet *pibOct, octet *PbG2Oct, octet *PgG1Oct, octet *AKeyG1Oct, octet *IdBOct, octet *AESKeyOct);
 extern int WCC_ZZZ_RECEIVER_KEY(int sha, octet *yOct, octet *wOct,  octet *piaOct, octet *pibOct, octet *PaG1Oct, octet *PgG1Oct, octet *BKeyG2Oct, octet *IdAOct, octet *AESKeyOct);
 extern void AES_GCM_ENCRYPT(octet *K,octet *IV,octet *H,octet *P,octet *C,octet *T);
@@ -149,11 +150,11 @@ if __name__ == "__main__":
     IdA[0].len = len(alice_id)
 
     # Hash value of IdA
-    AHV = ffi.new("octet*")
-    AHVval = ffi.new("char []", HASH_BYTES)
-    AHV[0].val = AHVval
-    AHV[0].max = HASH_BYTES
-    AHV[0].len = HASH_BYTES
+    HIdA = ffi.new("octet*")
+    HIdAval = ffi.new("char []", HASH_BYTES)
+    HIdA[0].val = HIdAval
+    HIdA[0].max = HASH_BYTES
+    HIdA[0].len = HASH_BYTES
 
     # Bob Identity
     bob_id = raw_input("Please enter Bob's identity:")
@@ -164,11 +165,11 @@ if __name__ == "__main__":
     IdB[0].len = len(bob_id)
 
     # Hash value of IdB
-    BHV = ffi.new("octet*")
-    BHVval = ffi.new("char []", HASH_BYTES)
-    BHV[0].val = BHVval
-    BHV[0].max = HASH_BYTES
-    BHV[0].len = HASH_BYTES
+    HIdB = ffi.new("octet*")
+    HIdBval = ffi.new("char []", HASH_BYTES)
+    HIdB[0].val = HIdBval
+    HIdB[0].max = HASH_BYTES
+    HIdB[0].len = HASH_BYTES
 
     # Sender keys
     A1KeyG1 = ffi.new("octet*")
@@ -270,23 +271,30 @@ if __name__ == "__main__":
     PbG2[0].len = G2
 
     # Assign a seed value
-    RAW = ffi.new("octet*")
-    RAWval = ffi.new("char [%s]" % len(seed), seed)
-    RAW[0].val = RAWval
-    RAW[0].len = len(seed)
-    RAW[0].max = len(seed)
+    SEED = ffi.new("octet*")
+    SEEDval = ffi.new("char [%s]" % len(seed), seed)
+    SEED[0].val = SEEDval
+    SEED[0].len = len(seed)
+    SEED[0].max = len(seed)
     if DEBUG:
-        print "RAW: %s" % toHex(RAW)
+        print "SEED: %s" % toHex(SEED)
 
     # random number generator
     RNG = ffi.new("csprng*")
-    libamcl_core.CREATE_CSPRNG(RNG, RAW)
+    libamcl_core.CREATE_CSPRNG(RNG, SEED)
 
-    # Identities
+    # Hash IdA
+    libamcl_core.HASH_ID(HASH_TYPE_WCC_ZZZ, IdA, HIdA)
     if DEBUG:
         print "IdA: %s" % toHex(IdA)
-        print "IdB: %s" % toHex(IdB)
+        print "HIdA: %s" % toHex(HIdA)
 
+    # Hash IdB
+    libamcl_core.HASH_ID(HASH_TYPE_WCC_ZZZ, IdB, HIdB)
+    if DEBUG:
+        print "IdB: %s" % toHex(IdB)
+        print "HIdB: %s" % toHex(HIdB)
+        
     # Generate master secret for MIRACL and Customer
     rtn = libamcl_wcc_ZZZ.WCC_ZZZ_RANDOM_GENERATE(RNG, MS1)
     if rtn != 0:
@@ -299,12 +307,12 @@ if __name__ == "__main__":
         print "MS2: %s" % toHex(MS2)
 
     # Generate Alice's sender key shares
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ, MS1, IdA, A1KeyG1)
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(MS1, HIdA, A1KeyG1)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,MS1,IdA,A1KeyG1) Error %s" % rtn
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ, MS2, IdA, A2KeyG1)
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(MS1,HIdA,A1KeyG1) Error %s" % rtn
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(MS2, HIdA, A2KeyG1)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,MS2,IdA,A2KeyG1) Error %s" % rtn
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(MS2,HIdA,A2KeyG1) Error %s" % rtn
     if DEBUG:
         print "A1KeyG1: %s" % toHex(A1KeyG1)
         print "A2KeyG1: %s" % toHex(A2KeyG1)
@@ -316,12 +324,12 @@ if __name__ == "__main__":
     print "AKeyG1: %s" % toHex(AKeyG1)
 
     # Generate Bob's receiver secret key shares
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ, MS1, IdB, B1KeyG2)
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(MS1, HIdB, B1KeyG2)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,MS1,IdB,B1KeyG2) Error %s" % rtn
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ, MS2, IdB, B2KeyG2)
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(MS1,HIdB,B1KeyG2) Error %s" % rtn
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(MS2, HIdB, B2KeyG2)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ,MS2,IdB,B2KeyG2) Error %s" % rtn
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(MS2,HIdB,B2KeyG2) Error %s" % rtn
     if DEBUG:
         print "B1KeyG2: %s" % toHex(B1KeyG2)
         print "B2KeyG2: %s" % toHex(B2KeyG2)
@@ -338,9 +346,9 @@ if __name__ == "__main__":
     if DEBUG:
         print "X: %s" % toHex(X)
 
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ, X, IdA, PaG1)
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(X, HIdA, PaG1)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ,X,IdA,PaG1) Error %s", rtn
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(X,HIdA,PaG1) Error %s", rtn
     if DEBUG:
         print "PaG1: %s" % toHex(PaG1)
 
@@ -350,9 +358,9 @@ if __name__ == "__main__":
     if DEBUG:
         print "W: %s" % toHex(W)
 
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ, W, IdA, PgG1)
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(W, HIdA, PgG1)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(HASH_TYPE_WCC_ZZZ, W, IdA, PgG1) Error %s", rtn
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G1_MULTIPLE(W, HIdA, PgG1) Error %s", rtn
     if DEBUG:
         print "PgG1: %s" % toHex(PgG1)
 
@@ -362,9 +370,9 @@ if __name__ == "__main__":
     if DEBUG:
         print "Y: %s" % toHex(Y)
 
-    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ, Y, IdB, PbG2)
+    rtn = libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(Y, HIdB, PbG2)
     if rtn != 0:
-        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(HASH_TYPE_WCC_ZZZ, Y, IdB, PbG2) Error %s", rtn
+        print "libamcl_wcc_ZZZ.WCC_ZZZ_GET_G2_MULTIPLE(Y, HIdB, PbG2) Error %s", rtn
     if DEBUG:
         print "PbG2: %s" % toHex(PbG2)
 


### PR DESCRIPTION
The functions that are multiplying points in G1 and G2 now only accepted identities that have been hashed.