### PR TITLE
remove unused variable k from ecp_mapit

### DIFF
--- a/src/ecp.c.in
+++ b/src/ecp.c.in
@@ -371,12 +371,10 @@ void ECP_ZZZ_mapit(ECP_ZZZ *P,octet *W)
     BIG_XXX_fromBytes(x,W->val);
     BIG_XXX_rcopy(q,Modulus_YYY);
     BIG_XXX_mod(x,q);
-    int k=0;
 
     while (!ECP_ZZZ_setx(P,x,0))
     {
         BIG_XXX_inc(x,1);
-        k++;
         BIG_XXX_norm(x);
     }
 #if PAIRING_FRIENDLY_ZZZ == BLS


### PR DESCRIPTION
Very small and little relevant fix.

However I wanted to use this occasion also to ask you if in your opinion is desirable to change the second `mapit` argument to the curve's `BIG` type. Right now the argument can be any `octet` which is not efficient and makes the function's usage error prone.

If it is desirable, I am happy to take care for such an API change.
